### PR TITLE
fix(#41): Component fails to apply due to wrong SSM value

### DIFF
--- a/src/provider-mysql.tf
+++ b/src/provider-mysql.tf
@@ -9,7 +9,7 @@ locals {
 
   mysql_admin_user         = module.aurora_mysql.outputs.aurora_mysql_master_username
   mysql_admin_password_key = module.aurora_mysql.outputs.aurora_mysql_master_password_ssm_key
-  mysql_admin_password     = local.enabled ? (length(var.mysql_admin_password) > 0 ? var.mysql_admin_password : data.aws_ssm_parameter.mysql_admin_password[0].value) : ""
+  mysql_admin_password     = local.enabled ? (length(var.mysql_admin_password) > 0 ? var.mysql_admin_password : data.aws_ssm_parameter.admin_password[0].value) : ""
 }
 
 data "aws_ssm_parameter" "admin_password" {

--- a/src/provider-mysql.tf
+++ b/src/provider-mysql.tf
@@ -9,7 +9,7 @@ locals {
 
   mysql_admin_user         = module.aurora_mysql.outputs.aurora_mysql_master_username
   mysql_admin_password_key = module.aurora_mysql.outputs.aurora_mysql_master_password_ssm_key
-  mysql_admin_password     = local.enabled ? (length(var.mysql_admin_password) > 0 ? var.mysql_admin_password : data.aws_ssm_parameter.admin_password[0].value) : ""
+  #mysql_admin_password     = local.enabled ? (length(var.mysql_admin_password) > 0 ? var.mysql_admin_password : one(data.aws_ssm_parameter.admin_password[*].value)) : ""
 }
 
 data "aws_ssm_parameter" "admin_password" {


### PR DESCRIPTION
## what
* Implements fix for #41 

## why
* Because current state of component is un-deployable 

## references
* `closes #41`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated and renamed internal infrastructure configuration for MySQL admin password sourcing to improve consistency and maintainability. No functional or user-facing behavior changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->