### PR TITLE
feat: support IAM-authenticated users and MySQL roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,15 +88,26 @@ components:
           - aurora-mysql-resources/defaults
       vars:
         aurora_mysql_component_name: aurora-mysql/dev
+        # Roles (MySQL 8.0+) are GRANT targets that users can be granted membership in
+        additional_roles:
+          - reader
         additional_users:
+          # Password-authenticated user (password generated and stored in SSM)
           example:
             db_user: example
             db_password: ""
             grants:
-              - grant: ["ALL"]
+              - grant: ["ALL_APP"]
                 db: example
-                object_type: database
-                schema: null
+          # IAM-authenticated user (no password), granted membership in the `reader` role
+          reporting:
+            db_user: reporting
+            auth_plugin: AWSAuthenticationPlugin
+            role_memberships:
+              - reader
+            grants:
+              - grant: ["SELECT"]
+                db: example
 ```
 
 > [!IMPORTANT]
@@ -120,13 +131,14 @@ components:
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0.0 |
 | <a name="requirement_mysql"></a> [mysql](#requirement\_mysql) | >= 3.0.22 |
+| <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 2.0.0, < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0, < 6.0.0 |
-| <a name="provider_mysql"></a> [mysql](#provider\_mysql) | >= 3.0.22 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.100.0 |
+| <a name="provider_mysql"></a> [mysql](#provider\_mysql) | 3.0.93 |
 
 ## Modules
 
@@ -134,7 +146,7 @@ components:
 |------|--------|---------|
 | <a name="module_additional_grants"></a> [additional\_grants](#module\_additional\_grants) | ./modules/mysql-user | n/a |
 | <a name="module_additional_users"></a> [additional\_users](#module\_additional\_users) | ./modules/mysql-user | n/a |
-| <a name="module_aurora_mysql"></a> [aurora\_mysql](#module\_aurora\_mysql) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
+| <a name="module_aurora_mysql"></a> [aurora\_mysql](#module\_aurora\_mysql) | cloudposse/stack-config/yaml//modules/remote-state | 2.0.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
@@ -143,6 +155,8 @@ components:
 | Name | Type |
 |------|------|
 | [mysql_database.additional](https://registry.terraform.io/providers/petoju/mysql/latest/docs/resources/database) | resource |
+| [mysql_role.additional](https://registry.terraform.io/providers/petoju/mysql/latest/docs/resources/role) | resource |
+| [aws_ssm_parameter.admin_password](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.password](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 
 ## Inputs
@@ -151,8 +165,9 @@ components:
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_databases"></a> [additional\_databases](#input\_additional\_databases) | Additional databases to be created with the cluster | `set(string)` | `[]` | no |
 | <a name="input_additional_grants"></a> [additional\_grants](#input\_additional\_grants) | Create additional database user with specified grants.<br/>If `var.ssm_password_source` is set, passwords will be retrieved from SSM parameter store,<br/>otherwise, passwords will be generated and stored in SSM parameter store under the service's key. | <pre>map(list(object({<br/>    grant : list(string)<br/>    db : string<br/>  })))</pre> | `{}` | no |
+| <a name="input_additional_roles"></a> [additional\_roles](#input\_additional\_roles) | MySQL roles to create. Roles are GRANT targets that can be granted to users via<br/>`additional_users[*].role_memberships`. Requires MySQL 8.0+. | `set(string)` | `[]` | no |
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br/>This is for some rare cases where resources want additional configuration of tags<br/>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
-| <a name="input_additional_users"></a> [additional\_users](#input\_additional\_users) | Create additional database user for a service, specifying username, grants, and optional password.<br/>If no password is specified, one will be generated. Username and password will be stored in<br/>SSM parameter store under the service's key. | <pre>map(object({<br/>    db_user : string<br/>    db_password : string<br/>    grants : list(object({<br/>      grant : list(string)<br/>      db : string<br/>    }))<br/>  }))</pre> | `{}` | no |
+| <a name="input_additional_users"></a> [additional\_users](#input\_additional\_users) | Create additional database user for a service, specifying username, grants, and optional password.<br/>If no password is specified, one will be generated. Username and password will be stored in<br/>SSM parameter store under the service's key.<br/>Set `auth_plugin` (e.g. `AWSAuthenticationPlugin` for RDS IAM authentication) to create a user<br/>that authenticates via a MySQL authentication plugin instead of a password; no password is<br/>generated or stored for such users. `role_memberships` grants the listed MySQL roles (see<br/>`var.additional_roles`) to the user. | <pre>map(object({<br/>    db_user : string<br/>    db_password : optional(string, "")<br/>    auth_plugin : optional(string, "")<br/>    role_memberships : optional(list(string), [])<br/>    grants : optional(list(object({<br/>      grant : list(string)<br/>      db : string<br/>    })), [])<br/>  }))</pre> | `{}` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br/>in the order they appear in the list. New attributes are appended to the<br/>end of the list. The elements of the list are joined by the `delimiter`<br/>and treated as a single ID element. | `list(string)` | `[]` | no |
 | <a name="input_aurora_mysql_component_name"></a> [aurora\_mysql\_component\_name](#input\_aurora\_mysql\_component\_name) | Aurora MySQL component name to read the remote state from | `string` | `"aurora-mysql"` | no |
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br/>See description of individual variables for details.<br/>Leave string and numeric variables as `null` to use default value.<br/>Individual variable settings (non-null) override settings in context object,<br/>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br/>  "additional_tag_map": {},<br/>  "attributes": [],<br/>  "delimiter": null,<br/>  "descriptor_formats": {},<br/>  "enabled": true,<br/>  "environment": null,<br/>  "id_length_limit": null,<br/>  "label_key_case": null,<br/>  "label_order": [],<br/>  "label_value_case": null,<br/>  "labels_as_tags": [<br/>    "unset"<br/>  ],<br/>  "name": null,<br/>  "namespace": null,<br/>  "regex_replace_chars": null,<br/>  "stage": null,<br/>  "tags": {},<br/>  "tenant": null<br/>}</pre> | no |
@@ -165,6 +180,7 @@ components:
 | <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br/>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br/>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
 | <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br/>set as tag values, and output by this module individually.<br/>Does not affect values of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br/>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br/>Default value: `lower`. | `string` | `null` | no |
 | <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br/>Default is to include all labels.<br/>Tags with empty values will not be included in the `tags` output.<br/>Set to `[]` to suppress all generated tags.<br/>**Notes:**<br/>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br/>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br/>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br/>  "default"<br/>]</pre> | no |
+| <a name="input_mysql_admin_password"></a> [mysql\_admin\_password](#input\_mysql\_admin\_password) | MySQL password for the admin user. If not provided, the password will be pulled from SSM | `string` | `""` | no |
 | <a name="input_mysql_cluster_enabled"></a> [mysql\_cluster\_enabled](#input\_mysql\_cluster\_enabled) | Set to `false` to prevent the module from creating any resources | `string` | `true` | no |
 | <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br/>This is the only ID element not also included as a `tag`.<br/>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |

--- a/README.yaml
+++ b/README.yaml
@@ -43,15 +43,26 @@ usage: |-
             - aurora-mysql-resources/defaults
         vars:
           aurora_mysql_component_name: aurora-mysql/dev
+          # Roles (MySQL 8.0+) are GRANT targets that users can be granted membership in
+          additional_roles:
+            - reader
           additional_users:
+            # Password-authenticated user (password generated and stored in SSM)
             example:
               db_user: example
               db_password: ""
               grants:
-                - grant: ["ALL"]
+                - grant: ["ALL_APP"]
                   db: example
-                  object_type: database
-                  schema: null
+            # IAM-authenticated user (no password), granted membership in the `reader` role
+            reporting:
+              db_user: reporting
+              auth_plugin: AWSAuthenticationPlugin
+              role_memberships:
+                - reader
+              grants:
+                - grant: ["SELECT"]
+                  db: example
   ```
 references:
   - name: cloudposse-terraform-components

--- a/src/README.md
+++ b/src/README.md
@@ -48,15 +48,26 @@ components:
           - aurora-mysql-resources/defaults
       vars:
         aurora_mysql_component_name: aurora-mysql/dev
+        # Roles (MySQL 8.0+) are GRANT targets that users can be granted membership in
+        additional_roles:
+          - reader
         additional_users:
+          # Password-authenticated user (password generated and stored in SSM)
           example:
             db_user: example
             db_password: ""
             grants:
-              - grant: ["ALL"]
+              - grant: ["ALL_APP"]
                 db: example
-                object_type: database
-                schema: null
+          # IAM-authenticated user (no password), granted membership in the `reader` role
+          reporting:
+            db_user: reporting
+            auth_plugin: AWSAuthenticationPlugin
+            role_memberships:
+              - reader
+            grants:
+              - grant: ["SELECT"]
+                db: example
 ```
 
 
@@ -68,13 +79,14 @@ components:
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0.0 |
 | <a name="requirement_mysql"></a> [mysql](#requirement\_mysql) | >= 3.0.22 |
+| <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 2.0.0, < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0, < 6.0.0 |
-| <a name="provider_mysql"></a> [mysql](#provider\_mysql) | >= 3.0.22 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.100.0 |
+| <a name="provider_mysql"></a> [mysql](#provider\_mysql) | 3.0.93 |
 
 ## Modules
 
@@ -82,7 +94,7 @@ components:
 |------|--------|---------|
 | <a name="module_additional_grants"></a> [additional\_grants](#module\_additional\_grants) | ./modules/mysql-user | n/a |
 | <a name="module_additional_users"></a> [additional\_users](#module\_additional\_users) | ./modules/mysql-user | n/a |
-| <a name="module_aurora_mysql"></a> [aurora\_mysql](#module\_aurora\_mysql) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
+| <a name="module_aurora_mysql"></a> [aurora\_mysql](#module\_aurora\_mysql) | cloudposse/stack-config/yaml//modules/remote-state | 2.0.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
@@ -91,6 +103,8 @@ components:
 | Name | Type |
 |------|------|
 | [mysql_database.additional](https://registry.terraform.io/providers/petoju/mysql/latest/docs/resources/database) | resource |
+| [mysql_role.additional](https://registry.terraform.io/providers/petoju/mysql/latest/docs/resources/role) | resource |
+| [aws_ssm_parameter.admin_password](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.password](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 
 ## Inputs
@@ -99,8 +113,9 @@ components:
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_databases"></a> [additional\_databases](#input\_additional\_databases) | Additional databases to be created with the cluster | `set(string)` | `[]` | no |
 | <a name="input_additional_grants"></a> [additional\_grants](#input\_additional\_grants) | Create additional database user with specified grants.<br/>If `var.ssm_password_source` is set, passwords will be retrieved from SSM parameter store,<br/>otherwise, passwords will be generated and stored in SSM parameter store under the service's key. | <pre>map(list(object({<br/>    grant : list(string)<br/>    db : string<br/>  })))</pre> | `{}` | no |
+| <a name="input_additional_roles"></a> [additional\_roles](#input\_additional\_roles) | MySQL roles to create. Roles are GRANT targets that can be granted to users via<br/>`additional_users[*].role_memberships`. Requires MySQL 8.0+. | `set(string)` | `[]` | no |
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br/>This is for some rare cases where resources want additional configuration of tags<br/>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
-| <a name="input_additional_users"></a> [additional\_users](#input\_additional\_users) | Create additional database user for a service, specifying username, grants, and optional password.<br/>If no password is specified, one will be generated. Username and password will be stored in<br/>SSM parameter store under the service's key. | <pre>map(object({<br/>    db_user : string<br/>    db_password : string<br/>    grants : list(object({<br/>      grant : list(string)<br/>      db : string<br/>    }))<br/>  }))</pre> | `{}` | no |
+| <a name="input_additional_users"></a> [additional\_users](#input\_additional\_users) | Create additional database user for a service, specifying username, grants, and optional password.<br/>If no password is specified, one will be generated. Username and password will be stored in<br/>SSM parameter store under the service's key.<br/>Set `auth_plugin` (e.g. `AWSAuthenticationPlugin` for RDS IAM authentication) to create a user<br/>that authenticates via a MySQL authentication plugin instead of a password; no password is<br/>generated or stored for such users. `role_memberships` grants the listed MySQL roles (see<br/>`var.additional_roles`) to the user. | <pre>map(object({<br/>    db_user : string<br/>    db_password : optional(string, "")<br/>    auth_plugin : optional(string, "")<br/>    role_memberships : optional(list(string), [])<br/>    grants : optional(list(object({<br/>      grant : list(string)<br/>      db : string<br/>    })), [])<br/>  }))</pre> | `{}` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br/>in the order they appear in the list. New attributes are appended to the<br/>end of the list. The elements of the list are joined by the `delimiter`<br/>and treated as a single ID element. | `list(string)` | `[]` | no |
 | <a name="input_aurora_mysql_component_name"></a> [aurora\_mysql\_component\_name](#input\_aurora\_mysql\_component\_name) | Aurora MySQL component name to read the remote state from | `string` | `"aurora-mysql"` | no |
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br/>See description of individual variables for details.<br/>Leave string and numeric variables as `null` to use default value.<br/>Individual variable settings (non-null) override settings in context object,<br/>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br/>  "additional_tag_map": {},<br/>  "attributes": [],<br/>  "delimiter": null,<br/>  "descriptor_formats": {},<br/>  "enabled": true,<br/>  "environment": null,<br/>  "id_length_limit": null,<br/>  "label_key_case": null,<br/>  "label_order": [],<br/>  "label_value_case": null,<br/>  "labels_as_tags": [<br/>    "unset"<br/>  ],<br/>  "name": null,<br/>  "namespace": null,<br/>  "regex_replace_chars": null,<br/>  "stage": null,<br/>  "tags": {},<br/>  "tenant": null<br/>}</pre> | no |
@@ -113,6 +128,7 @@ components:
 | <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br/>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br/>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
 | <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br/>set as tag values, and output by this module individually.<br/>Does not affect values of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br/>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br/>Default value: `lower`. | `string` | `null` | no |
 | <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br/>Default is to include all labels.<br/>Tags with empty values will not be included in the `tags` output.<br/>Set to `[]` to suppress all generated tags.<br/>**Notes:**<br/>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br/>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br/>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br/>  "default"<br/>]</pre> | no |
+| <a name="input_mysql_admin_password"></a> [mysql\_admin\_password](#input\_mysql\_admin\_password) | MySQL password for the admin user. If not provided, the password will be pulled from SSM | `string` | `""` | no |
 | <a name="input_mysql_cluster_enabled"></a> [mysql\_cluster\_enabled](#input\_mysql\_cluster\_enabled) | Set to `false` to prevent the module from creating any resources | `string` | `true` | no |
 | <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br/>This is the only ID element not also included as a `tag`.<br/>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |

--- a/src/main.tf
+++ b/src/main.tf
@@ -35,7 +35,7 @@ resource "mysql_role" "additional" {
 }
 
 module "additional_users" {
-  for_each = var.additional_users
+  for_each = local.mysql_enabled ? var.additional_users : {}
   source   = "./modules/mysql-user"
 
   service_name     = each.key

--- a/src/main.tf
+++ b/src/main.tf
@@ -27,19 +27,29 @@ resource "mysql_database" "additional" {
   name = each.key
 }
 
+# Create MySQL roles before users so `additional_users[*].role_memberships` can reference them.
+resource "mysql_role" "additional" {
+  for_each = local.mysql_enabled ? var.additional_roles : []
+
+  name = each.key
+}
+
 module "additional_users" {
   for_each = var.additional_users
   source   = "./modules/mysql-user"
 
-  service_name    = each.key
-  db_user         = each.value.db_user
-  db_password     = each.value.db_password
-  grants          = each.value.grants
-  ssm_path_prefix = local.ssm_path_prefix
-  kms_key_id      = local.kms_key_arn
+  service_name     = each.key
+  db_user          = each.value.db_user
+  db_password      = each.value.db_password
+  auth_plugin      = each.value.auth_plugin
+  role_memberships = each.value.role_memberships
+  grants           = each.value.grants
+  ssm_path_prefix  = local.ssm_path_prefix
+  kms_key_id       = local.kms_key_arn
 
   depends_on = [
     mysql_database.additional,
+    mysql_role.additional,
   ]
 
   context = module.this.context

--- a/src/modules/mysql-user/main.tf
+++ b/src/modules/mysql-user/main.tf
@@ -1,10 +1,14 @@
 locals {
   enabled = module.this.enabled
 
+  # Password machinery applies only to password-authenticated users. Users with an
+  # `auth_plugin` set (e.g. RDS IAM auth) have no password to generate or store.
+  use_password = local.enabled && var.auth_plugin == ""
+
   db_user     = length(var.db_user) > 0 ? var.db_user : var.service_name
   db_password = length(var.db_password) > 0 ? var.db_password : join("", random_password.db_password[*].result)
 
-  save_password_in_ssm = local.enabled && var.save_password_in_ssm
+  save_password_in_ssm = local.use_password && var.save_password_in_ssm
 
   db_password_key = format("%s/%s/passwords/%s", var.ssm_path_prefix, var.service_name, local.db_user)
   db_password_ssm = local.save_password_in_ssm ? {
@@ -36,7 +40,7 @@ locals {
 }
 
 resource "random_password" "db_password" {
-  count   = local.enabled && length(var.db_password) == 0 ? 1 : 0
+  count   = local.use_password && length(var.db_password) == 0 ? 1 : 0
   length  = 33
   special = false
 
@@ -46,10 +50,23 @@ resource "random_password" "db_password" {
 }
 
 resource "mysql_user" "default" {
-  count              = local.enabled ? 1 : 0
-  user               = local.db_user
-  host               = "%"
-  plaintext_password = local.db_password
+  count = local.enabled ? 1 : 0
+  user  = local.db_user
+  host  = "%"
+  # Password users set `plaintext_password`; auth-plugin users (e.g. RDS IAM) set `auth_plugin`
+  # instead and have no password.
+  plaintext_password = var.auth_plugin == "" ? local.db_password : null
+  auth_plugin        = var.auth_plugin == "" ? null : var.auth_plugin
+}
+
+# Grant MySQL role memberships to the user (GRANT <role> TO <user>).
+resource "mysql_grant" "role_membership" {
+  count = local.enabled && length(var.role_memberships) > 0 ? 1 : 0
+  user  = join("", mysql_user.default[*].user)
+  host  = join("", mysql_user.default[*].host)
+  roles = var.role_memberships
+
+  depends_on = [mysql_user.default]
 }
 
 # Grant the user full access to this specific database

--- a/src/modules/mysql-user/variables.tf
+++ b/src/modules/mysql-user/variables.tf
@@ -46,3 +46,19 @@ variable "kms_key_id" {
   default     = "alias/aws/rds"
   description = "KMS key ID, ARN, or alias to use for encrypting MySQL database"
 }
+
+variable "auth_plugin" {
+  type        = string
+  default     = ""
+  description = <<-EOT
+    MySQL authentication plugin for the user (e.g. `AWSAuthenticationPlugin` for RDS IAM
+    authentication). When set, the user authenticates via the plugin and no password is
+    generated or stored in SSM.
+    EOT
+}
+
+variable "role_memberships" {
+  type        = list(string)
+  default     = []
+  description = "List of MySQL roles to grant to the user created by this module."
+}

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -52,17 +52,32 @@ variable "additional_users" {
   # map key is service name
   type = map(object({
     db_user : string
-    db_password : string
-    grants : list(object({
+    db_password : optional(string, "")
+    auth_plugin : optional(string, "")
+    role_memberships : optional(list(string), [])
+    grants : optional(list(object({
       grant : list(string)
       db : string
-    }))
+    })), [])
   }))
   default     = {}
   description = <<-EOT
     Create additional database user for a service, specifying username, grants, and optional password.
     If no password is specified, one will be generated. Username and password will be stored in
     SSM parameter store under the service's key.
+    Set `auth_plugin` (e.g. `AWSAuthenticationPlugin` for RDS IAM authentication) to create a user
+    that authenticates via a MySQL authentication plugin instead of a password; no password is
+    generated or stored for such users. `role_memberships` grants the listed MySQL roles (see
+    `var.additional_roles`) to the user.
+    EOT
+}
+
+variable "additional_roles" {
+  type        = set(string)
+  default     = []
+  description = <<-EOT
+    MySQL roles to create. Roles are GRANT targets that can be granted to users via
+    `additional_users[*].role_memberships`. Requires MySQL 8.0+.
     EOT
 }
 

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -70,6 +70,14 @@ variable "additional_users" {
     generated or stored for such users. `role_memberships` grants the listed MySQL roles (see
     `var.additional_roles`) to the user.
     EOT
+
+  validation {
+    condition = alltrue([
+      for user in values(var.additional_users) :
+      !(trimspace(user.auth_plugin) != "" && trimspace(user.db_password) != "")
+    ])
+    error_message = "additional_users[*] cannot set both `db_password` and `auth_plugin`; auth-plugin users do not use a password."
+  }
 }
 
 variable "additional_roles" {


### PR DESCRIPTION
## what

Adds support for **IAM-authenticated MySQL users** and **MySQL roles**, bringing this component to parity with `aws-aurora-postgres-resources` for role/membership management.

- `additional_roles` (set) → creates `mysql_role` resources (GRANT targets; MySQL 8.0+).
- `additional_users[*].auth_plugin` → creates users that authenticate via a MySQL authentication plugin (e.g. `AWSAuthenticationPlugin` for RDS IAM Database Authentication). No password is generated or stored in SSM for such users.
- `additional_users[*].role_memberships` → GRANTs the listed roles to the user (`mysql_grant { roles = [...] }`).
- `additional_users` `db_password` and `grants` are now optional, so role-only / IAM users can be declared without a password or grants. **Backward compatible** (existing password users are unchanged).

The `mysql-user` module gates all password machinery behind `auth_plugin == ""`, sets `auth_plugin` on `mysql_user` for plugin users, and adds a `mysql_grant` with `roles` for role memberships.

## why

Closes #40.

Today the component assumes password-based users, so IAM-auth users and roles must be created manually via SQL, breaking declarative IaC. This lets them be declared in the stack config.

### Note on the interface

Issue #40 sketched a nested `auth: { type: iam }` abstraction. This PR instead exposes the raw MySQL `auth_plugin` string  -  it's more general (supports any plugin, not just IAM) and maps directly to the `petoju/mysql` provider's `mysql_user.auth_plugin`. The IAM use case is satisfied with `auth_plugin: AWSAuthenticationPlugin`. Happy to add a friendlier `auth.type` wrapper on top if maintainers prefer.

## references / testing

- Example usage (also updated in `README.yaml`):

```yaml
additional_roles:
  - reader
additional_users:
  example:                       # password user (unchanged behavior)
    db_user: example
    db_password: ""
    grants:
      - grant: ["ALL_APP"]
        db: example
  reporting:                     # IAM user, no password, member of `reader`
    db_user: reporting
    auth_plugin: AWSAuthenticationPlugin
    role_memberships:
      - reader
    grants:
      - grant: ["SELECT"]
        db: example
```

- `terraform fmt` clean; `terraform validate` passes on the `mysql-user` module.
- This repo has no Terratest suite (`test/` is a placeholder), so the change was validated against a **live Aurora MySQL 8.0 cluster** via a downstream Atmos deployment: `terraform plan` is clean (`No changes`) with the roles, IAM user, and role memberships applied.
- `README.md` / `src/README.md` regenerated via `atmos docs generate readme` / `readme-simple`. (Also fixed the prior usage example, which used Postgres-only `object_type`/`schema` grant fields that are invalid for MySQL.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MySQL 8.0+ support for defining additional roles and granting role memberships to additional users.
  * Expanded additional user configuration with optional `auth_plugin` (including IAM-style authentication) and `role_memberships`, with validation to prevent mixing password and plugin auth.
  * Updated documentation and usage examples to reflect the new role-based grant model, plus new inputs like `mysql_admin_password`.

* **Bug Fixes**
  * Improved reliability by only generating/storing passwords when password authentication is used, and by applying role-related resources in the correct order.

* **Documentation**
  * Refreshed README and example snippets for updated configuration and provider/module version pinning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
